### PR TITLE
Adhoc

### DIFF
--- a/bin/wifi
+++ b/bin/wifi
@@ -3,7 +3,7 @@ from __future__ import print_function
 import argparse
 import sys
 
-from wifi import * # NOQA
+from wifi import *  # NOQA
 
 
 def scan_command(args):
@@ -37,22 +37,33 @@ parser_scan.set_defaults(func=scan_command)
 parser_list = subparsers.add_parser('list', help="Shows a list of networks already configured.")
 parser_list.set_defaults(func=list_command)
 
-scheme_help = "A memorable nickname for a wireless network.  If SSID is not provided, the network will be guessed using SCHEME."
-ssid_help = "The SSID for the network to which you wish to connect.  This is fuzzy matched, so you don't have to be precise."
+scheme_help = ("A memorable nickname for a wireless network."
+               "  If SSID is not provided, the network will be guessed using SCHEME.")
+ssid_help = ("The SSID for the network to which you wish to connect."
+             "  This is fuzzy matched, so you don't have to be precise.")
 
-parser_show = subparsers.add_parser('config', help="Prints the configuration to connect to a new network.")
+parser_show = subparsers.add_parser('config',
+                                    help="Prints the configuration to connect to a new network.")
 parser_show.add_argument('scheme', help=scheme_help, metavar='SCHEME')
 parser_show.add_argument('ssid', nargs='?', help=ssid_help, metavar='SSID')
 parser_show.set_defaults(func=show_command)
 
-parser_add = subparsers.add_parser('add', help="Adds the configuration to connect to a new network.")
+parser_add = subparsers.add_parser('add',
+                                   help="Adds the configuration to connect to a new network.")
 parser_add.add_argument('scheme', help=scheme_help, metavar='SCHEME')
 parser_add.add_argument('ssid', nargs='?', help=ssid_help, metavar='SSID')
 parser_add.set_defaults(func=add_command)
 
-parser_connect = subparsers.add_parser('connect', help="Connects to the network corresponding to SCHEME")
-parser_connect.add_argument('scheme', help="The nickname of the network to which you wish to connect.", metavar='SCHEME')
-parser_connect.add_argument('-a', '--ad-hoc', dest='adhoc', action="store_true", help="Connect to a network without storing it in the config file")
+parser_connect = subparsers.add_parser('connect',
+                                       help="Connects to the network corresponding to SCHEME")
+parser_connect.add_argument('scheme',
+                            help="The nickname of the network to which you wish to connect.",
+                            metavar='SCHEME')
+parser_connect.add_argument('-a',
+                            '--ad-hoc',
+                            dest='adhoc',
+                            action="store_true",
+                            help="Connect to a network without storing it in the config file")
 parser_connect.set_defaults(func=connect_command)
 
 

--- a/wifi/__init__.py
+++ b/wifi/__init__.py
@@ -84,9 +84,9 @@ def configuration(cell):
     """
     if cell['encrypted'] == 'off':
         return {
-                'wireless-essid': cell['ssid'],
-                'wireless-channel': 'auto',
-                }
+            'wireless-essid': cell['ssid'],
+            'wireless-channel': 'auto',
+        }
     else:
         if cell.get('encryption_type') == 'WPA2':
             passkey = raw_input('wpa passkey> ')
@@ -95,10 +95,10 @@ def configuration(cell):
                 passkey = pbkdf2_hex(passkey, cell['ssid'], 4096, 32)
 
             return {
-                    'wpa-ssid': cell['ssid'],
-                    'wpa-psk': passkey,
-                    'wireless-channel': 'auto',
-                    }
+                'wpa-ssid': cell['ssid'],
+                'wpa-psk': passkey,
+                'wireless-channel': 'auto',
+            }
         else:
             raise NotImplementedError
 
@@ -127,6 +127,7 @@ def find_cell(query):
     assert num_matches < 2, "Found more than one network that matches '{}'".format(query)
 
     return matches[0]
+
 
 def show(scheme, ssid=None):
     """
@@ -163,7 +164,8 @@ def connect(scheme, adhoc=False):
     if adhoc:
         cell = find_cell(scheme)
         config = configuration(cell)
-        args = list(itertools.chain.from_iterable(('-o', '{k}={v}'.format(k=k, v=v)) for k, v in config.items()))
+        args = list(itertools.chain.from_iterable(
+            ('-o', '{k}={v}'.format(k=k, v=v)) for k, v in config.items()))
         subprocess.check_call(['/sbin/ifdown', 'wlan0'])
         subprocess.check_call(['/sbin/ifup', 'wlan0'] + args)
     else:


### PR DESCRIPTION
`wifi connect -a <search>`

Connects to a network without storing it in the config file

Still requires a

```
  iface wlan0 inet dhcp
```

interfaces(5) setting to make ifup aware of wlan0. So we may have to add back `wifi init`
