### PR TITLE
Cells whose entire SSID is a substring of others weren't usable.

### DIFF
--- a/bin/wifi
+++ b/bin/wifi
@@ -8,7 +8,7 @@ from wifi import Cell, Scheme
 from wifi.utils import print_table, match as fuzzy_match
 
 
-def find_cell(interface, query):
+def fuzzy_find_cell(interface, query):
     match_partial = lambda cell: fuzzy_match(query, cell.ssid)
 
     matches = Cell.where(interface, match_partial)
@@ -18,6 +18,16 @@ def find_cell(interface, query):
     assert num_matches < 2, "Found more than one network that matches '{}'".format(query)
 
     return matches[0]
+
+
+def find_cell(interface, query):
+    cell = Cell.where(interface, lambda cell: cell.ssid.lower() == query.lower())
+
+    try:
+        cell = cell[0]
+    except IndexError:
+        cell = fuzzy_find_cell(interface, query)
+    return cell
 
 
 def scheme_for_ssid(interface, scheme, ssid=None):


### PR DESCRIPTION
For example if there were two networks Apple and App, it was impossible
to connect to App.

The find_cell code now first checks to see if there is a network SSID that matches exactly before using fuzzy search.
