### PR TITLE
Feature: I want to be able to specify the location of the interfaces file.

### DIFF
--- a/bin/wifi
+++ b/bin/wifi
@@ -35,12 +35,11 @@ def find_cell(interface, query):
     return cell
 
 
-def scheme_for_ssid(interface, scheme, ssid=None):
+def get_scheme_params(interface, scheme, ssid=None):
     cell = find_cell(interface, ssid or scheme)
-
     passkey = None if not cell.encrypted else input('passkey> ')
 
-    return Scheme.for_cell(interface, scheme, cell, passkey)
+    return interface, scheme, cell, passkey
 
 
 def scan_command(args):
@@ -48,34 +47,36 @@ def scan_command(args):
 
 
 def list_command(args):
-    for scheme in Scheme.all():
+    for scheme in Scheme.for_file(args.file).all():
         print(scheme.name)
 
 
 def show_command(args):
-    scheme = scheme_for_ssid(args.interface, args.scheme, args.ssid)
+    scheme = Scheme.for_file(args.file).for_cell(*get_scheme_params(args.interface, args.scheme, args.ssid))
     print(scheme)
 
 
 def add_command(args):
-    assert not Scheme.find(args.interface, args.scheme), "That scheme has already been used"
+    scheme_class = Scheme.for_file(args.file)
+    assert not scheme_class.find(args.interface, args.scheme), "That scheme has already been used"
 
-    scheme = scheme_for_ssid(args.interface, args.scheme, args.ssid)
+    scheme = scheme_class.for_cell(*get_scheme_params(args.interface, args.scheme, args.ssid))
     scheme.save()
 
 
 def connect_command(args):
+    scheme_class = Scheme.for_file(args.file)
     if args.adhoc:
         # ensure that we have the adhoc utility scheme
         try:
-            adhoc_scheme = Scheme(args.interface, 'adhoc')
+            adhoc_scheme = scheme_class(args.interface, 'adhoc')
             adhoc_scheme.save()
         except AssertionError:
             pass
 
-        scheme = scheme_for_ssid(args.interface, 'adhoc', args.scheme)
+        scheme = scheme_class.for_cell(*get_scheme_params(args.interface, 'adhoc', args.scheme, args.file))
     else:
-        scheme = Scheme.find(args.interface, args.scheme)
+        scheme = scheme_class.find(args.interface, args.scheme)
         assert scheme, "Couldn't find a scheme named %r, did you mean to use -a?" % args.scheme
 
     scheme.activate()
@@ -86,6 +87,10 @@ parser.add_argument('-i',
                     '--interface',
                     default='wlan0',
                     help="Specifies which interface to use (wlan0, eth0, etc.)")
+parser.add_argument('-f',
+                    '--file',
+                    default='/etc/network/interfaces',
+                    help="Specifies which file for scheme storage.")
 
 subparsers = parser.add_subparsers(title='commands')
 
@@ -125,7 +130,8 @@ parser_connect.add_argument('-a',
 parser_connect.set_defaults(func=connect_command)
 
 
-parser_connect.options = [scheme.name for scheme in Scheme.all()]
+# TODO: how to specify the correct interfaces file to work off of.
+parser_connect.get_options = lambda: [scheme.name for scheme in Scheme.all()]
 
 
 def autocomplete(position, wordlist):
@@ -134,7 +140,7 @@ def autocomplete(position, wordlist):
     else:
         try:
             prev = wordlist[position - 1]
-            ret = subparsers.choices[prev].options
+            ret = subparsers.choices[prev].get_options()
         except (IndexError, KeyError, AttributeError):
             ret = []
 

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -38,10 +38,12 @@ iface wlan0-coffee2 inet dhcp
 
 class TestSchemes(TestCase):
     def setUp(self):
-        self.tempfile, Scheme.interfaces = tempfile.mkstemp()
+        self.tempfile, interfaces = tempfile.mkstemp()
 
-        with open(Scheme.interfaces, 'w') as f:
+        with open(interfaces, 'w') as f:
             f.write(NETWORK_INTERFACES_FILE)
+
+        self.Scheme = Scheme.for_file(interfaces)
 
     def test_scheme_extraction(self):
         work, coffee, home, coffee2 = extract_schemes(NETWORK_INTERFACES_FILE)
@@ -53,22 +55,22 @@ class TestSchemes(TestCase):
         assert coffee.options['wireless-essid'] == 'Coffee WiFi'
 
     def test_str(self):
-        scheme = Scheme('wlan0', 'test')
+        scheme = self.Scheme('wlan0', 'test')
         assert str(scheme) == 'iface wlan0-test inet dhcp\n'
 
-        scheme = Scheme('wlan0', 'test', {
+        scheme = self.Scheme('wlan0', 'test', {
             'wpa-ssid': 'workwifi',
         })
 
         self.assertEqual(str(scheme), 'iface wlan0-test inet dhcp\n    wpa-ssid workwifi\n')
 
     def test_find(self):
-        work = Scheme.find('wlan0', 'work')
+        work = self.Scheme.find('wlan0', 'work')
 
         assert work.options['wpa-ssid'] == 'workwifi'
 
     def test_save(self):
-        scheme = Scheme('wlan0', 'test')
+        scheme = self.Scheme('wlan0', 'test')
         scheme.save()
 
-        assert Scheme.find('wlan0', 'test')
+        assert self.Scheme.find('wlan0', 'test')

--- a/wifi/utils.py
+++ b/wifi/utils.py
@@ -37,3 +37,10 @@ def print_table(matrix, sep='  ', file=sys.stdout, *args, **kwargs):
 
     for row in matrix:
         print(format.format(*row).strip(), file=file, *args, **kwargs)
+
+
+def ensure_file_exists(filename):
+    """
+    http://stackoverflow.com/a/12654798/1013960
+    """
+    open(filename, 'a').close()


### PR DESCRIPTION
It would be cool to be able to not have to edit the global /etc/network/interfaces file...  While it does provide compatibility with something like ifscheme, it's not really super great thing I think.

Something like:

``` sh
$ wifi --file ~/.interfaces connect home
```

It would also allow us to have "profiles".

I also want there to be a .wifirc file.  It would allow user to specify defaults for --interface and --file.
