### PR TITLE
Fill missing "Channel" field

### DIFF
--- a/tests/test_parsing.py
+++ b/tests/test_parsing.py
@@ -34,6 +34,12 @@ class IWListParserTest(TestCase):
         cell = Cell.from_string(NONAME_WIRELESS_NETWORK)
         self.assertEqual(cell.ssid, '')
 
+    def test_no_channel_output(self):
+        # https://github.com/rockymeza/wifi/issues/24
+        cell = Cell.from_string(NO_CHANNEL_OUTPUT)
+        self.assertEqual(cell.channel, 11)
+
+
 
 
 IWLIST_SCAN_NO_ENCRYPTION = """Cell 02 - Address: 38:83:45:CC:58:74
@@ -155,4 +161,19 @@ NONAME_WIRELESS_NETWORK = """Cell 01 - Address: A4:56:30:E8:97:F0
                         Pairwise Ciphers (2) : TKIP CCMP
                         Authentication Suites (1) : PSK
                     Quality=84/100  Signal level=43/100  
+"""
+
+NO_CHANNEL_OUTPUT = """Cell 06 - Address: 
+                    ESSID:
+                    Protocol:IEEE 802.11bgn
+                    Mode:Master
+                    Frequency:2.462 GHz (Channel 11)
+                    Encryption key:on
+                    Bit Rates:144 Mb/s
+                    Extra:rsn_ie=30140100000fac040100000fac040100000fac020c00
+                    IE: IEEE 802.11i/WPA2 Version 1
+                        Group Cipher : CCMP
+                        Pairwise Ciphers (1) : CCMP
+                        Authentication Suites (1) : PSK
+                    Quality=93/100  Signal level=10/100 
 """

--- a/wifi/scan.py
+++ b/wifi/scan.py
@@ -45,14 +45,8 @@ class Cell(object):
 cells_re = re.compile(r'Cell \d+ - ')
 quality_re_dict = {'dBm': re.compile(r'Quality=(\d+/\d+).*Signal level=(-\d+) dBm'),
                    'relative': re.compile(r'Quality=(\d+/\d+).*Signal level=(\d+/\d+)')}
-frequency_re = re.compile(r'([\d\.]+ .Hz).*')
+frequency_re = re.compile(r'([\d\.]+ .Hz).*Channel\s+(\d+).*')
 
-
-scalars = (
-    'address',
-    'channel',
-    'mode',
-)
 
 identity = lambda x: x
 
@@ -71,9 +65,7 @@ def normalize_key(key):
 
 normalize_value = {
     'ssid': lambda v: v.strip('"'),
-    'frequency': lambda v: frequency_re.search(v).group(1),
     'encrypted': lambda v: v == 'on',
-    'channel': int,
     'address': identity,
     'mode': identity,
 }
@@ -130,6 +122,10 @@ def normalize(cell_block):
 
                 if 'WPA2' in value:
                     cell.encryption_type = 'wpa2'
+            if key == 'frequency':
+                frequency, channel = frequency_re.search(value).groups()
+                cell.frequency = frequency
+                cell.channel = int(channel)
             elif key in normalize_value:
                 setattr(cell, key, normalize_value[key](value))
 


### PR DESCRIPTION
For some reason my output from 'iwlist wlan0 scanning'  is missing a channel field.

However, the channel is present at the frequency field:
       Frequency:2.457 GHz (Channel 10) 

So to use this value if it is available or the channel field if it is available this is what I did:

To solve this I changed and added these lines to scan.py:

``` python
quality_re_dict = {'dBm': re.compile(r'Quality=(\d+/\d+).*Signal level=(-\d+) dBm'),
                   'relative': re.compile(r'Quality=(\d+/\d+).*Signal level=(\d+/\d+)')}
frequency_re = re.compile(r'([\d\.]+ .Hz).*Channel (\d+).*')

```

``` python
normalize_value = {
     'ssid': lambda v: v.strip('"'),
#    'frequency': lambda v: frequency_re.search(v).group(1),
     'encrypted': lambda v: v == 'on',
```

``` python
            if 'WPA2' in value:
                    cell.encryption_type = 'wpa2'
            elif key == 'frequency':
                setattr(cell, 'frequency'  ,frequency_re.search(value).group(1) )
                setattr(cell, 'channel'  ,int(frequency_re.search(value).group(2) ))
            elif key in normalize_value:
                setattr(cell, key, normalize_value[key](value))
```

Hope you can insert it to the code so that it might help some one else too.
