### PR TITLE
Status command

### DIFF
--- a/bin/wifi
+++ b/bin/wifi
@@ -96,10 +96,8 @@ def autoconnect_command(args):
     ssids = [cell.ssid for cell in Cell.all(args.interface)]
 
     for scheme in Scheme.all():
-        # TODO: make it easier to get the SSID off of a scheme.
-        ssid = scheme.options.get('wpa-ssid', scheme.options.get('wireless-essid'))
-        if ssid in ssids:
-            sys.stderr.write('Connecting to "%s".\n' % ssid)
+        if scheme.ssid in ssids:
+            sys.stderr.write('Connecting to "%s".\n' % scheme.ssid)
             try:
                 scheme.activate()
             except ConnectionError:

--- a/bin/wifi
+++ b/bin/wifi
@@ -4,7 +4,7 @@ import argparse
 import sys
 import os
 
-from wifi import Cell, Scheme
+from wifi import Cell, Scheme, Connection
 from wifi.utils import print_table, match as fuzzy_match
 from wifi.exceptions import ConnectionError, InterfaceError
 
@@ -67,6 +67,18 @@ def add_command(args):
 
     scheme = scheme_class.for_cell(*get_scheme_params(args.interface, args.scheme, args.ssid))
     scheme.save()
+
+
+def status_command(args):
+    connection = Connection.current(args.interface)
+    if connection:
+        scheme = connection.scheme
+        print_table([
+            ("scheme:", scheme.name),
+            ("ssid:", scheme.ssid),
+        ])
+    else:
+        print("Not connected")
 
 
 def connect_command(args):
@@ -165,6 +177,9 @@ def arg_parser():
              " available and connects to the first one it finds."
     )
     parser_autoconnect.set_defaults(func=autoconnect_command)
+
+    parser_status = subparsers.add_parser('status', help="Show information about the currently active network.")
+    parser_status.set_defaults(func=status_command)
 
     return parser, subparsers
 

--- a/docs/scanning.rst
+++ b/docs/scanning.rst
@@ -58,6 +58,9 @@ Once you have a scheme saved, you can retrieve it using :meth:`Scheme.find`. ::
     You must be root to connect to a network.
     Wifi uses `ifdown` and `ifup` to connect and disconnect.
 
+The activate method on the :class:`Scheme` class returns a :class:`Connection`
+object.
+
 
 .. autoclass:: Cell
     :members:
@@ -66,3 +69,34 @@ Once you have a scheme saved, you can retrieve it using :meth:`Scheme.find`. ::
     :members:
 
     .. attribute:: ssid
+
+.. autoclass:: Connection
+
+    .. attribute:: scheme
+
+        The scheme that represents the current network.
+
+    .. attribute:: ipv4
+
+        The IPv4 Address for the connection.  This may be None.
+
+    .. attribute:: ipv6
+
+        The IPv6 Address for the connection.  This may be None.
+
+    .. classmethod:: current
+
+        Returns a connection object based on the currently activated
+        :class:`Scheme`.  This method may return None. ::
+
+            >>> from wifi import Scheme, Connection
+            >>> scheme = Scheme.find('wlan0', 'home')
+            >>> scheme.activate()
+            >>> c = Connection.current('wlan0')
+            >>> c.scheme == scheme
+            True
+
+        .. note::
+
+            It is possible for this method to incorrectly guess which scheme is
+            being selected if there is more than one scheme for the same SSID.

--- a/docs/scanning.rst
+++ b/docs/scanning.rst
@@ -64,3 +64,5 @@ Once you have a scheme saved, you can retrieve it using :meth:`Scheme.find`. ::
 
 .. autoclass:: Scheme
     :members:
+
+    .. attribute:: ssid

--- a/docs/wifi_command.rst
+++ b/docs/wifi_command.rst
@@ -140,6 +140,13 @@ first one it finds. ::
 
     usage: wifi autoconnect
 
+status
+------
+
+Shows information about the currently active network. ::
+
+    usage: wifi status
+
 
 Completion
 ^^^^^^^^^^

--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ def read(fname):
 install_requires = [
     'setuptools',
     'pbkdf2',
+    'netifaces',
 ]
 try:
     import argparse

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -4,7 +4,6 @@ import os
 
 from wifi import Cell
 from wifi.scheme import extract_schemes, Scheme
-from wifi.exceptions import ConnectionError
 
 
 NETWORK_INTERFACES_FILE = """
@@ -88,18 +87,6 @@ class TestSchemes(TestCase):
         assert self.Scheme.find('wlan0', 'test')
 
 
-class TestActivation(TestCase):
-    def test_successful_connection(self):
-        scheme = Scheme('wlan0', 'test')
-        connection = scheme.parse_ifup_output(SUCCESSFUL_IFUP_OUTPUT)
-        self.assertEqual(connection.scheme, scheme)
-        self.assertEqual(connection.ip_address, '192.168.1.113')
-
-    def test_failed_connection(self):
-        scheme = Scheme('wlan0', 'test')
-        self.assertRaises(ConnectionError, scheme.parse_ifup_output, FAILED_IFUP_OUTPUT)
-
-
 class TestForCell(TestCase):
     def test_unencrypted(self):
         cell = Cell()
@@ -153,7 +140,6 @@ class TestForCell(TestCase):
             'wpa-psk': 'ea1548d4e8850c8d94c5ef9ed6fe483981b64c1436952cb1bf80c08a68cdc763',
             'wireless-channel': 'auto',
         })
-
 
 
 SUCCESSFUL_IFDOWN_OUTPUT = """Internet Systems Consortium DHCP Client 4.2.4

--- a/wifi/__init__.py
+++ b/wifi/__init__.py
@@ -1,2 +1,3 @@
 from wifi.scan import Cell
 from wifi.scheme import Scheme
+from wifi.connection import Connection

--- a/wifi/connection.py
+++ b/wifi/connection.py
@@ -1,0 +1,62 @@
+import netifaces
+
+from .scheme import Scheme
+
+
+def get_ip_address_for_interface(interface):
+    ip_addresses = netifaces.ifaddresses(interface)
+    ipv4_list = ip_addresses.get(netifaces.AF_INET)
+    try:
+        ipv4 = ipv4_list[0]['addr']
+    except (IndexError, KeyError):
+        ipv4 = None
+    ipv6_list = ip_addresses.get(netifaces.AF_INET6)
+    try:
+        ipv6 = ipv6_list[0]['addr']
+    except (IndexError, KeyError):
+        ipv6 = None
+
+    return ipv4, ipv6
+
+
+class Connection(object):
+    """
+    The connection object returned when connecting to a Scheme.
+    """
+    def __init__(self, scheme, ipv4=None, ipv6=None):
+        self.scheme = scheme
+        self.ipv4 = ipv4
+        self.ipv6 = ipv6
+
+    def __repr__(self):
+        return 'Connection(scheme={scheme!r}, ipv4={ipv4}, ipv6={ipv6})'.format(**vars(self))
+
+    @classmethod
+    def current_for_scheme(cls, scheme):
+        """
+        Returns a connection object based on the current connection for the
+        specified scheme.  If it is determined that there is no connection,
+        this may return None.
+        """
+        ipv4, ipv6 = get_ip_address_for_interface(scheme.interface)
+
+        if not ipv4 and not ipv6:
+            return None
+
+        return cls(scheme, ipv4=ipv4, ipv6=ipv6)
+
+    @classmethod
+    def current(cls, interface):
+        """
+        Derives the current connection based on the current scheme for the
+        specified interface.
+        """
+        schemes = Scheme.current(interface)
+        if schemes is None:
+            return None
+        elif not schemes:
+            scheme = Scheme(interface, None)
+        else:
+            scheme = schemes[0]
+
+        return cls.current_for_scheme(scheme)

--- a/wifi/connection.py
+++ b/wifi/connection.py
@@ -8,12 +8,12 @@ def get_ip_address_for_interface(interface):
     ipv4_list = ip_addresses.get(netifaces.AF_INET)
     try:
         ipv4 = ipv4_list[0]['addr']
-    except (IndexError, KeyError):
+    except (IndexError, KeyError, TypeError):
         ipv4 = None
     ipv6_list = ip_addresses.get(netifaces.AF_INET6)
     try:
         ipv6 = ipv6_list[0]['addr']
-    except (IndexError, KeyError):
+    except (IndexError, KeyError, TypeError):
         ipv6 = None
 
     return ipv4, ipv6

--- a/wifi/scheme.py
+++ b/wifi/scheme.py
@@ -169,10 +169,11 @@ class Scheme(object):
         from .connection import Connection
 
         subprocess.check_output(['/sbin/ifdown', self.interface], stderr=subprocess.STDOUT)
-        subprocess.check_output(['/sbin/ifup'] + self.as_args(), stderr=subprocess.STDOUT)
+        output = subprocess.check_output(['/sbin/ifup'] + self.as_args(), stderr=subprocess.PIPE)
 
         connection = Connection.current_for_scheme(self)
         if not connection:
+            print(output)
             raise ConnectionError("Failed to connect to %r" % self)
         else:
             return connection

--- a/wifi/scheme.py
+++ b/wifi/scheme.py
@@ -109,6 +109,20 @@ class Scheme(object):
         """
         return cls(interface, name, configuration(cell, passkey))
 
+    @classmethod
+    def current(cls, interface):
+        """
+        Returns a list of all the schemes that it is possible that are
+        currently activated.  May return None if no scheme is currently
+        activaated.
+        """
+        try:
+            scheme_name = subprocess.check_output(['/sbin/iwgetid', '--raw', '--scheme', interface], stderr=subprocess.STDOUT).strip().decode('ascii')
+        except subprocess.CalledProcessError:
+            return None
+
+        return Scheme.where(lambda s: s.interface == interface and s.ssid == scheme_name)
+
     @property
     def ssid(self):
         return self.options.get('wpa-ssid', self.options.get('wireless-essid'))

--- a/wifi/scheme.py
+++ b/wifi/scheme.py
@@ -109,6 +109,10 @@ class Scheme(object):
         """
         return cls(interface, name, configuration(cell, passkey))
 
+    @property
+    def ssid(self):
+        return self.options.get('wpa-ssid', self.options.get('wireless-essid'))
+
     def save(self):
         """
         Writes the configuration to the :attr:`interfaces` file.


### PR DESCRIPTION
I busted the Connection about out into it's own module
and added functionality for determining the currently active connection.
I also removed the parse_ifup_output method from Scheme because it was
causing issues (see #43).  In its stead, I am using the capabilities
from the Connection object.

There is now a status command.  Currently the status command itself pretty limited, but there is room for growth.

``` sh
$ sudo wifi status
scheme:  home
ssid:    SSID
```

This pull request also addresses #43.
