### PR TITLE
Check for write access for bashcompletion via os.access (Alternative version)

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,16 @@ except:
 
 version = '1.0.0'
 
+data_files = [
+    ('/etc/bash_completion.d/', ['extras/wifi-completion.bash']),
+]
+for entry in data_files:
+    # make sure we actually have write access to the target folder and if not don't
+    # include it in data_files
+    if not os.access(entry[0], os.W_OK):
+        print("Skipping copying files to %s, no write access" % entry[0])
+        data_files.remove(entry)
+
 setup(
     name='wifi',
     version=version,
@@ -46,7 +56,5 @@ setup(
         "Programming Language :: Python :: 2.7",
         "Programming Language :: Python :: 3.3",
     ],
-    data_files=[
-        ('/etc/bash_completion.d/', ['extras/wifi-completion.bash']),
-    ]
+    data_files=data_files
 )


### PR DESCRIPTION
Alternative version of pull request rockymeza/wifi#41 (which apparently
isn't worked on any more) which checks for write access before
attempting to install the bashcompletion addition during
installation -- if only installed in a library into a virtualenv
the installation will now complete without an issue.
