### PR TITLE
Having an AP with an ssid containing the minus symbol

### DIFF
--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -36,6 +36,10 @@ iface wlan0-home inet dhcp
 iface wlan0-coffee2 inet dhcp
     wireless-essid Coffee 2
     wireless-channel auto
+
+iface wlan0-with-hyphen inet dhcp
+    wireless-channel auto
+    wireless-essid with-hyphen
 """
 
 
@@ -52,13 +56,17 @@ class TestSchemes(TestCase):
         os.remove(self.Scheme.interfaces)
 
     def test_scheme_extraction(self):
-        work, coffee, home, coffee2 = extract_schemes(NETWORK_INTERFACES_FILE)
+        work, coffee, home, coffee2 = list(extract_schemes(NETWORK_INTERFACES_FILE))[:4]
 
         assert work.name == 'work'
         assert work.options['wpa-ssid'] == 'workwifi'
 
         assert coffee.name == 'coffee'
         assert coffee.options['wireless-essid'] == 'Coffee WiFi'
+
+    def test_with_hyphen(self):
+        with_hyphen = self.Scheme.find('wlan0', 'with-hyphen')
+        assert with_hyphen.options['wireless-essid'] == 'with-hyphen'
 
     def test_str(self):
         scheme = self.Scheme('wlan0', 'test')

--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -40,6 +40,10 @@ iface wlan0-coffee2 inet dhcp
 iface wlan0-with-hyphen inet dhcp
     wireless-channel auto
     wireless-essid with-hyphen
+
+iface xyz1-scheme inet dhcp
+    wireless-channel auto
+    wireless-essid scheme
 """
 
 
@@ -67,6 +71,9 @@ class TestSchemes(TestCase):
     def test_with_hyphen(self):
         with_hyphen = self.Scheme.find('wlan0', 'with-hyphen')
         assert with_hyphen.options['wireless-essid'] == 'with-hyphen'
+
+    def test_with_different_interface(self):
+        assert self.Scheme.find('xyz1', 'scheme')
 
     def test_str(self):
         scheme = self.Scheme('wlan0', 'test')

--- a/wifi/scheme.py
+++ b/wifi/scheme.py
@@ -175,8 +175,7 @@ class Connection(object):
         self.ip_address = ip_address
 
 
-# TODO: support other interfaces
-scheme_re = re.compile(r'iface\s+(?P<interface>wlan\d?)(?:-(?P<name>\S+))?')
+scheme_re = re.compile(r'iface\s+(?P<interface>[^-]+)(?:-(?P<name>\S+))?')
 
 
 def extract_schemes(interfaces, scheme_class=Scheme):

--- a/wifi/scheme.py
+++ b/wifi/scheme.py
@@ -176,7 +176,7 @@ class Connection(object):
 
 
 # TODO: support other interfaces
-scheme_re = re.compile(r'iface\s+(?P<interface>wlan\d?)(?:-(?P<name>\w+))?')
+scheme_re = re.compile(r'iface\s+(?P<interface>wlan\d?)(?:-(?P<name>\S+))?')
 
 
 def extract_schemes(interfaces, scheme_class=Scheme):


### PR DESCRIPTION
I currently need to access a wireless Network wih an ssid like CompanyWifi-F8D7 and everytime i try to  find an already saved profile with find('wlan0','CompanyWifi-F8D7') (python library) it returns None. I already dived into the code and i think i've found the reason: your regex used in scheme_re on line 179 only allows \w characters, which doesn't include "-" symbols. 
I'm not sure if it is solved that easily so i would really appreciate your reply. Below my interfaces file:

auto lo

iface lo inet loopback

allow-hotplug wlan1
iface wlan1 inet manual
wpa-roam /etc/wpa_supplicant/wpa_supplicant.conf
iface default inet dhcp

#auto eth0
#iface eth0 inet static
#address 192.168.0.40
#netmask 255.255.255.0
#gateway 192.168.0.1

iface wlan0-CompanyWifi-F8D7 inet dhcp
    wireless-channel auto
    wireless-essid CompanyWifi-F8D7

iface wlan0-CompanyWifi-F8F7 inet dhcp
    wireless-channel auto
    wireless-essid CompanyWifi-F8F7


I'm running a debian wheezy on a raspberry pi (raspbian)