### PR TITLE
WEP passkeys in plaintext need to be prefixed with "s:" to function

### DIFF
--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -123,7 +123,7 @@ class TestForCell(TestCase):
 
         self.assertEqual(scheme.options, {
             'wireless-essid': 'SSID',
-            'wireless-key': 'passkey',
+            'wireless-key': 's:passkey',
         })
 
     def test_wpa2(self):

--- a/wifi/scheme.py
+++ b/wifi/scheme.py
@@ -31,7 +31,7 @@ def configuration(cell, passkey=None):
         elif cell.encryption_type == 'wep':
             return {
                 'wireless-essid': cell.ssid,
-                'wireless-key': passkey,
+                'wireless-key': 's:' + passkey,
             }
         else:
             raise NotImplementedError


### PR DESCRIPTION
Since we also handle WPA keyphrases as plain text keyphrases, it makes sense to equally preprocess the entered data from the user here too, instead of forcing him to manually add s: in front of plain text keyphrases.

Alternatively the documentation should hint the user that this is manual preprocessing is necessary, or a detection mechanism should be added to only add it if necessary (since the plain text passphrase might just be a 40bit hex string though, a simple regex would not be sufficient here, which is also why I opted for this radical approach).

Without this adjustment, trying to connect to a wep-"secured" wifi network supplying just the plain text keyphrase will fail due to an invalid encoding.