### PR TITLE
Only prefix obvious ASCII web keys with the s: parameter

### DIFF
--- a/tests/test_schemes.py
+++ b/tests/test_schemes.py
@@ -113,18 +113,37 @@ class TestForCell(TestCase):
             'wireless-channel': 'auto',
         })
 
-    def test_wep(self):
+    def test_wep_hex(self):
         cell = Cell()
         cell.ssid = 'SSID'
         cell.encrypted = True
         cell.encryption_type = 'wep'
 
-        scheme = Scheme.for_cell('wlan0', 'test', cell, 'passkey')
+        # hex key lengths: 10, 26, 32, 58
+        hex_keys = ("01234567ab", "0123456789abc" * 2, "0123456789abcdef" * 2, "0123456789abc" * 2 + "0123456789abcdef" * 2)
+        for key in hex_keys:
+            scheme = Scheme.for_cell('wlan0', 'test', cell, key)
 
-        self.assertEqual(scheme.options, {
-            'wireless-essid': 'SSID',
-            'wireless-key': 'passkey',
-        })
+            self.assertEqual(scheme.options, {
+                'wireless-essid': 'SSID',
+                'wireless-key': key
+            })
+
+    def test_wep_ascii(self):
+        cell = Cell()
+        cell.ssid = 'SSID'
+        cell.encrypted = True
+        cell.encryption_type = 'wep'
+
+        # ascii key lengths: 5, 13, 16, 29
+        ascii_keys = ('a' * 5, 'a' * 13, 'a' * 16, 'a' * 29)
+        for key in ascii_keys:
+            scheme = Scheme.for_cell('wlan0', 'test', cell, key)
+
+            self.assertEqual(scheme.options, {
+                'wireless-essid': 'SSID',
+                'wireless-key': 's:' + key
+            })
 
     def test_wpa2(self):
         cell = Cell()

--- a/wifi/scheme.py
+++ b/wifi/scheme.py
@@ -29,6 +29,23 @@ def configuration(cell, passkey=None):
                 'wireless-channel': 'auto',
             }
         elif cell.encryption_type == 'wep':
+            # Pass key lengths in bytes for WEP depend on type of key and key length:
+            #
+            #       64bit   128bit   152bit   256bit
+            # hex     10      26       32       58
+            # ASCII    5      13       16       29
+            #
+            # (source: https://en.wikipedia.org/wiki/Wired_Equivalent_Privacy)
+            #
+            # ASCII keys need to be prefixed with an s: in the interfaces file in order to work with linux' wireless
+            # tools
+
+            ascii_lengths = (5, 13, 16, 29)
+            if len(passkey) in ascii_lengths:
+                # we got an ASCII passkey here (otherwise the key length wouldn't match), we'll need to prefix that
+                # with s: in our config for the wireless tools to pick it up properly
+                passkey = "s:" + passkey
+
             return {
                 'wireless-essid': cell.ssid,
                 'wireless-key': passkey,


### PR DESCRIPTION
Better version of my previous pull request.

Turns out ASCII WEP keys (which in my tests Linux indeed absolutely needed to be prefixed with s: in order to be able to connect) are either 5, 13, 16 or 29 bytes long (and hexadecimal WEP keys are 10, 26, 32, 58 characters, so no collision), which the code now checks against in order to determine whether the prefix needs to be added or not.

I added unit tests and some inline documentation.

Using this patch and some more magic around it (to get the wifi driver to behave during fast switches from access point mode to client mode, which was what was an additional problem) I was finally able to reliably connect to a test WEP network utilizing an ASCII WEP key using this library.