### PR TITLE
Add sudo argument to Cell.all

### DIFF
--- a/wifi/scan.py
+++ b/wifi/scan.py
@@ -20,12 +20,15 @@ class Cell(object):
         return 'Cell(ssid={ssid})'.format(**vars(self))
 
     @classmethod
-    def all(cls, interface):
+    def all(cls, interface, sudo=False):
         """
         Returns a list of all cells extracted from the output of iwlist.
         """
+        args = ['/sbin/iwlist', interface, 'scan']
+        if sudo:
+            args.insert(0, 'sudo')
         try:
-            iwlist_scan = subprocess.check_output(['/sbin/iwlist', interface, 'scan'],
+            iwlist_scan = subprocess.check_output(args,
                                                   stderr=subprocess.STDOUT)
         except subprocess.CalledProcessError as e:
             raise InterfaceError(e.output.strip())


### PR DESCRIPTION
A user must have root access to list interfaces, but we don't
want to run python as root, which would be a big security issue.
So this PR allows to only give sudo access to `iwlist` to the user
running python.

I haven't see any unittests on `Cell.all` so I haven't added any. If I missed
something, please point me to it :)

cc @ametaireau