### PR TITLE
Set attributes as None in __init__

### DIFF
--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,0 +1,22 @@
+from unittest import TestCase
+
+from wifi.scan import Cell
+
+class CorrectInitTest(TestCase):
+    fields = {"ssid": None,
+              "bitrates": [],
+              "address": None,
+              "channel": None,
+              "encrypted": False,
+              "encryption_type": None,
+              "frequency": None,
+              "mode": None,
+              "quality": None,
+              "signal": None}
+
+
+    def test_empty_init(self):
+        tcell = Cell()
+
+        for field, value in self.fields.iteritems():
+            self.assertEqual(value, getattr(tcell, field))

--- a/wifi/scan.py
+++ b/wifi/scan.py
@@ -159,7 +159,7 @@ def normalize(cell_block):
 
     # It seems that encryption types other than WEP need to specify their
     # existence.
-    if cell.encrypted and not cell.encryption_type):
+    if cell.encrypted and not cell.encryption_type:
         cell.encryption_type = 'wep'
 
     return cell

--- a/wifi/scan.py
+++ b/wifi/scan.py
@@ -16,6 +16,14 @@ class Cell(object):
     def __init__(self):
         self.ssid = None
         self.bitrates = []
+        self.address = None
+        self.channel = None
+        self.encrypted = False
+        self.encryption_type = None
+        self.frequency = None
+        self.mode = None
+        self.quality = None
+        self.signal = None
 
     def __repr__(self):
         return 'Cell(ssid={ssid})'.format(**vars(self))
@@ -151,7 +159,7 @@ def normalize(cell_block):
 
     # It seems that encryption types other than WEP need to specify their
     # existence.
-    if cell.encrypted and not hasattr(cell, 'encryption_type'):
+    if cell.encrypted and not cell.encryption_type):
         cell.encryption_type = 'wep'
 
     return cell


### PR DESCRIPTION
Useful if you want to create a dummy Cell (not by scanning/parsing iwlist but by creating Cell object manually)