### PR TITLE
Bugfix for len None

### DIFF
--- a/wifi/scheme.py
+++ b/wifi/scheme.py
@@ -20,7 +20,7 @@ def configuration(cell, passkey=None):
         }
     else:
         if cell.encryption_type.startswith('wpa'):
-            if len(passkey) != 64:
+            if passkey and len(passkey) != 64:
                 passkey = PBKDF2(passkey, cell.ssid, 4096).hexread(32)
 
             return {


### PR DESCRIPTION
len(None) raises a TypeError with value:
TypeError: object of type 'NoneType' has no len()

i didnt see a contrib guide, so feel free to let me know how you want me to send features and bugfixes.  I'll probably send quite a few over the next few weeks. 
