### PR TITLE
Fix problem shutting down interfaces with names like wlan0-foobar sin…

### DIFF
--- a/wifi/scheme.py
+++ b/wifi/scheme.py
@@ -169,7 +169,7 @@ class Scheme(object):
         Connects to the network as configured in this scheme.
         """
 
-        subprocess.check_output(['/sbin/ifdown', self.interface], stderr=subprocess.STDOUT)
+        subprocess.check_output(['/sbin/ifdown', self.iface], stderr=subprocess.STDOUT)
         ifup_output = subprocess.check_output(['/sbin/ifup'] + self.as_args(), stderr=subprocess.STDOUT)
         ifup_output = ifup_output.decode('utf-8')
 


### PR DESCRIPTION
This is probably related to this issue: https://github.com/rockymeza/wifi/issues/102

Shutting down interfaces with compounded names like wlan0-XXXX fails since .interface does not include the full name like .iface