### PR TITLE
modified scheme.py to fix activete failed

### DIFF
--- a/wifi/scheme.py
+++ b/wifi/scheme.py
@@ -5,6 +5,7 @@ import wifi.subprocess_compat as subprocess
 from pbkdf2 import PBKDF2
 from wifi.utils import ensure_file_exists
 from wifi.exceptions import ConnectionError
+import time
 
 
 def configuration(cell, passkey=None):
@@ -171,6 +172,7 @@ class Scheme(object):
 
         subprocess.check_output(['/sbin/ifdown', self.interface], stderr=subprocess.STDOUT)
         ifup_output = subprocess.check_output(['/sbin/ifup'] + self.as_args(), stderr=subprocess.STDOUT)
+        time.sleep(0.1)
         ifup_output = ifup_output.decode('utf-8')
 
         return self.parse_ifup_output(ifup_output)


### PR DESCRIPTION
fix the bug of wifi.sheme. In the previous version, after create a scheme, scheme.activate function will fail with none-zero return code error. I found the problem happened due to no time delay between two commands -- ifdown & ifup in scheme.py(173). After a time delay, it can be solved!