### PR TITLE
Make the code compliant with Python 3.3 or higher (@nicolargo)

### DIFF
--- a/CHANGES.rst
+++ b/CHANGES.rst
@@ -9,6 +9,12 @@ Changelog
 - Add a __main__.py so that wifi can be invoked using python -mwifi
 - Fix argument parsing so that scan is the default argument even with options passed
 
+0.3.9
+^^^^^
+:release-date: 2018-12-26
+
+- Make the code compliant with Python 3.3 or higher (@nicolargo)
+
 0.3.8
 ^^^^^
 :release-date: 2016-03-11

--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,10 @@ PORT?=8008
 test:
 	python setup.py test
 
+test3:
+	 ~/virtualenv/glances-python3.6/bin/python setup.py test
+
+
 docs:
 	cd docs && $(MAKE) html
 

--- a/tests/test_init.py
+++ b/tests/test_init.py
@@ -1,6 +1,10 @@
 from unittest import TestCase
 
 from wifi.scan import Cell
+import sys
+
+PY3 = sys.version_info[0] == 3
+
 
 class CorrectInitTest(TestCase):
     fields = {"ssid": None,
@@ -14,9 +18,12 @@ class CorrectInitTest(TestCase):
               "quality": None,
               "signal": None}
 
-
     def test_empty_init(self):
         tcell = Cell()
 
-        for field, value in self.fields.iteritems():
-            self.assertEqual(value, getattr(tcell, field))
+        if PY3:
+            for field, value in self.fields.items():
+                self.assertEqual(value, getattr(tcell, field))
+        else:
+            for field, value in self.fields.iteritems():
+                self.assertEqual(value, getattr(tcell, field))

--- a/wifi/scan.py
+++ b/wifi/scan.py
@@ -6,6 +6,9 @@ import textwrap
 import wifi.subprocess_compat as subprocess
 from wifi.utils import db2dbm
 from wifi.exceptions import InterfaceError
+import sys
+
+PY3 = sys.version_info[0] == 3
 
 
 class Cell(object):
@@ -42,6 +45,8 @@ class Cell(object):
         else:
             iwlist_scan = iwlist_scan.decode('utf-8')
         cells = map(Cell.from_string, cells_re.split(iwlist_scan)[1:])
+        if PY3:
+            cells = list(cells)
 
         return cells
 


### PR DESCRIPTION
Hi @rockymeza ,

i am the maintainer of the Glances software (https://github.com/nicolargo/glances). It uses your nice lib to grab Wifi stats. Unfortunately, there is an issue with Python 3.3 or highers (see https://github.com/nicolargo/glances/issues/1373#issuecomment-449639945).

This pull request makes your lib compliant with Python 3.3 or higher. Can you review the PR, merge and tag a new version on Pypi ?

Thanks !